### PR TITLE
Use Distribution for Amount of Planets and Moons

### DIFF
--- a/InfiniteDiscoveries/GenerateSystem/GenerateSystem.py
+++ b/InfiniteDiscoveries/GenerateSystem/GenerateSystem.py
@@ -2320,7 +2320,7 @@ try:
         global totalPlanetsGenerated
         totalPlanetsGenerated = totalPlanetsGenerated + 1
         if planetsGenerated > 1:
-            moonAmount = math.floor(np.clip(scipy.stats.gamma.rvs(*Settings.moonDistributionArgs), Settings.minMoons, AmountOfMoonsToGenerate))
+            moonAmount = round(np.clip(scipy.stats.gamma.rvs(*Settings.moonDistributionArgs), Settings.minMoons, AmountOfMoonsToGenerate))
         else:
             moonAmount = 0
         planetName = starN + "-" + alphabet[planetsGenerated]

--- a/InfiniteDiscoveries/GenerateSystem/GenerateSystem.py
+++ b/InfiniteDiscoveries/GenerateSystem/GenerateSystem.py
@@ -15,6 +15,7 @@ try:
     import time
     import math
     import numpy as np
+    import scipy
     from scipy.signal import convolve2d
     import noise
     import sys
@@ -2319,7 +2320,7 @@ try:
         global totalPlanetsGenerated
         totalPlanetsGenerated = totalPlanetsGenerated + 1
         if planetsGenerated > 1:
-            moonAmount = random.randint(Settings.minMoons,AmountOfMoonsToGenerate)
+            moonAmount = math.floor(np.clip(scipy.stats.gamma.rvs(*Settings.moonDistributionArgs), Settings.minMoons, AmountOfMoonsToGenerate))
         else:
             moonAmount = 0
         planetName = starN + "-" + alphabet[planetsGenerated]
@@ -2694,12 +2695,11 @@ try:
         return starColor, starName, dispName
 
     def generateBarycenter(AmountOfPlanetsToGenerate):
-        planetsNum = random.randint(Settings.minPlanets,AmountOfPlanetsToGenerate)
+        planetsNum = math.floor(np.clip(scipy.stats.gamma.rvs(*Settings.planetDistributionArgs), Settings.minMoons, AmountOfPlanetsToGenerate))
         global planetsGenerated
         planetsGenerated = 0
         systemName = str(alphabet[random.randint(0,len(alphabet)-1)]) + str(alphabet[random.randint(0,len(alphabet)-1)]) + "-" + str(random.randint(0,99999))
 
-        planetsNum = random.randint(Settings.minPlanets,AmountOfPlanetsToGenerate)
         print(systemName)
         print("Number Of Planets For " + systemName + ": " + str(planetsNum))
         min = Settings.minStarSize

--- a/InfiniteDiscoveries/Settings.py
+++ b/InfiniteDiscoveries/Settings.py
@@ -6,7 +6,7 @@ minPlanets = 0 # Minimum number of planets per star.
 minMoons = 0 # Minimum number of moons per planet.
 
 planetDistributionArgs: tuple[float] = (6.0, -0.5, 0.5) # Arguments for the gamma distribution that is sampled for amount of planets
-moonDistributionArgs: tuple[float] = (2.0, 0.0, 1.0) # Arguments for the gamma distribution that is sampled for amount of moons
+moonDistributionArgs: tuple[float] = (2.0, -0.15, 0.5) # Arguments for the gamma distribution that is sampled for amount of moons
 
 fantasyNames = True # Generate a fantasy name for bodies. Will not affect internal names!
 

--- a/InfiniteDiscoveries/Settings.py
+++ b/InfiniteDiscoveries/Settings.py
@@ -5,8 +5,8 @@ convertTexturesToDDS = True # Will remove the requirement for ImageMagick and re
 minPlanets = 0 # Minimum number of planets per star.
 minMoons = 0 # Minimum number of moons per planet.
 
-planetDistributionArgs: tuple[float] = (2.0, 0.0, 1.0)
-moonDistributionArgs: tuple[float] = (6.0, -0.5, 0.5)
+planetDistributionArgs: tuple[float] = (6.0, -0.5, 0.5) # Arguments for the gamma distribution that is sampled for amount of planets
+moonDistributionArgs: tuple[float] = (2.0, 0.0, 1.0) # Arguments for the gamma distribution that is sampled for amount of moons
 
 fantasyNames = True # Generate a fantasy name for bodies. Will not affect internal names!
 

--- a/InfiniteDiscoveries/Settings.py
+++ b/InfiniteDiscoveries/Settings.py
@@ -5,6 +5,9 @@ convertTexturesToDDS = True # Will remove the requirement for ImageMagick and re
 minPlanets = 0 # Minimum number of planets per star.
 minMoons = 0 # Minimum number of moons per planet.
 
+planetDistributionArgs: tuple[float] = (2.0, 0.0, 1.0)
+moonDistributionArgs: tuple[float] = (6.0, -0.5, 0.5)
+
 fantasyNames = True # Generate a fantasy name for bodies. Will not affect internal names!
 
 # Generator settings. These settings will greatly affect the generator speed.


### PR DESCRIPTION
Instead of getting a random number for the number of planets and moons to generate. Use a gamma distribution that is fit to generate systems that usually have one or two planets, usually with one moon. Though having neither is still common. I did this because I felt like I often ran into stars with no planets. And I didn't want to set a minimum amount.

You can also edit the parameters of the gamma distribution in Setting.py. Although I used a gamma distribution there is nothing really special about it. It just looked closest to the real distribution of exoplanets I was seeing online.

### Planet distribution
![Planet distribution](https://github.com/user-attachments/assets/f51b68d1-d811-4c8c-83aa-facd0a4c36aa)
### Moon distribution
![Moon distribution](https://github.com/user-attachments/assets/0a6c3247-8f16-4380-aac5-5ddaea8a6061)
